### PR TITLE
bindTexture using wrong enum

### DIFF
--- a/src/si/virag/AndroidOpenGLVideoDemo/gl/VideoTextureRenderer.java
+++ b/src/si/virag/AndroidOpenGLVideoDemo/gl/VideoTextureRenderer.java
@@ -177,7 +177,7 @@ public class VideoTextureRenderer extends TextureSurfaceRenderer implements Surf
         GLES20.glEnableVertexAttribArray(positionHandle);
         GLES20.glVertexAttribPointer(positionHandle, 3, GLES20.GL_FLOAT, false, 4 * 3, vertexBuffer);
 
-        GLES20.glBindTexture(GLES20.GL_TEXTURE0, textures[0]);
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textures[0]);
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
         GLES20.glUniform1i(textureParamHandle, 0);
 


### PR DESCRIPTION
logcat gets spammed with WRONG_ENUM and Fixed 0x500 back and forth on adreno platforms, potentially slowing down rendering by a tick or two. nothing major but worth pointing out
