### PR TITLE
null videoTexure exception crash fix

### DIFF
--- a/src/si/virag/AndroidOpenGLVideoDemo/SurfaceActivity.java
+++ b/src/si/virag/AndroidOpenGLVideoDemo/SurfaceActivity.java
@@ -55,6 +55,9 @@ public class SurfaceActivity extends Activity implements TextureView.SurfaceText
         renderer = new VideoTextureRenderer(this, surface.getSurfaceTexture(), surfaceWidth, surfaceHeight);
         player = new MediaPlayer();
 
+		// wait for OpenGL to finish initializing
+		while (renderer.getVideoTexture() == null);
+
         try
         {
             AssetFileDescriptor afd = getAssets().openFd("big_buck_bunny.mp4");


### PR DESCRIPTION
Fixed runtime exception (videoTexture is null) on line: 

```
player.setSurface(new Surface(renderer.getVideoTexture()));
```

OpenGL is initialized in separate thread, and sometimes is not initialized yet, before executing code above.
